### PR TITLE
fixed setPath() method + written some tests

### DIFF
--- a/src/Rememberme/Cookie.php
+++ b/src/Rememberme/Cookie.php
@@ -30,7 +30,7 @@ class Cookie {
     return $this->path;
   }
 
-  public function setPath(string $path) {
+  public function setPath($path) {
     $this->path = $path;
   }
 

--- a/test/CookieTest.php
+++ b/test/CookieTest.php
@@ -1,0 +1,31 @@
+<?php
+
+class CookieTest extends PHPUnit_Framework_TestCase
+{
+    public function testDefaultValues()
+    {
+        $cookie = new \Birke\Rememberme\Cookie();
+
+        $this->assertEquals('', $cookie->getPath());
+        $this->assertEquals('', $cookie->getDomain());
+        $this->assertFalse($cookie->getSecure());
+        $this->assertTrue($cookie->getHttpOnly());
+    }
+
+    public function testSetters()
+    {
+        $cookie = new \Birke\Rememberme\Cookie();
+
+        $cookie->setPath('/test');
+        $this->assertEquals('/test', $cookie->getPath());
+
+        $cookie->setDomain('www.foo.com');
+        $this->assertEquals('www.foo.com', $cookie->getDomain());
+
+        $cookie->setSecure(true);
+        $this->assertTrue($cookie->getSecure());
+
+        $cookie->setHttpOnly(false);
+        $this->assertFalse($cookie->getHttpOnly());
+    }
+}


### PR DESCRIPTION
Hi, setPath() method from Birke\Rememberme\Cookie class forces argument to be "string" which is a mistake I guess. I created a pull request and written some tests. If you're OK with it, please merge it.
