### PR TITLE
Call cleanTriplet() on successful login. "expires" column was not checked in SQL

### DIFF
--- a/src/Rememberme/Authenticator.php
+++ b/src/Rememberme/Authenticator.php
@@ -62,6 +62,7 @@ class Authenticator {
       case Storage\StorageInterface::TRIPLET_FOUND:
         $expire = time() + $this->expireTime;
         $newToken = $this->createToken();
+        $this->storage->cleanTriplet($cookieValues[0], $cookieValues[2].$this->salt);
         $this->storage->storeTriplet($cookieValues[0], $newToken.$this->salt, $cookieValues[2].$this->salt, $expire);
         $this->cookie->setCookie($this->cookieName, implode("|", array($cookieValues[0],$newToken, $cookieValues[2])), $expire);
         $loginResult = $cookieValues[0];

--- a/src/Rememberme/Storage/PDO.php
+++ b/src/Rememberme/Storage/PDO.php
@@ -23,7 +23,7 @@ class PDO extends DB {
     // proper XML test data
     $sql = "SELECT IF(SHA1(?) = {$this->tokenColumn}, 1, -1) AS token_match " .
            "FROM {$this->tableName} WHERE {$this->credentialColumn} = ? " .
-           "AND {$this->persistentTokenColumn} = SHA1(?) LIMIT 1 ";
+           "AND {$this->persistentTokenColumn} = SHA1(?) LIMIT 1 AND {$this->expiresColumn} > NOW()";
     $query = $this->connection->prepare($sql);
     $query->execute(array($token, $credential, $persistentToken));
     $result = $query->fetchColumn();


### PR DESCRIPTION
Hi,

According to http://jaspan.com/improved_persistent_login_cookie_best_practice, "If the triplet is present, the user is considered authenticated. The used token is removed from the database. A new token is generated, stored in database with the username and the same series identifier, and a new login cookie containing all three is issued to the user.". This was not being done in Authenticator.

Additionally, I added SQL condition for the token expiry date column. Without it, the user could have been autenticated using expired token, which is bad.

Please have a look and merge if it's OK.

Regards,
Bartosz
