### PR TITLE
Data inconsistency problems

### DIFF
--- a/src/Rememberme/Authenticator.php
+++ b/src/Rememberme/Authenticator.php
@@ -72,8 +72,7 @@ class Authenticator
             case Storage\StorageInterface::TRIPLET_FOUND:
                 $expire = time() + $this->expireTime;
                 $newToken = $this->createToken();
-                $this->storage->cleanTriplet($cookieValues[0], $cookieValues[2] . $this->salt);
-                $this->storage->storeTriplet($cookieValues[0], $newToken . $this->salt, $cookieValues[2] . $this->salt, $expire);
+                $this->storage->replaceTriplet($cookieValues[0], $newToken . $this->salt, $cookieValues[2] . $this->salt, $expire);
                 $this->cookie->setCookie($this->cookieName, implode("|", array($cookieValues[0], $newToken, $cookieValues[2])), $expire);
                 $loginResult = $cookieValues[0];
                 break;

--- a/src/Rememberme/Storage/File.php
+++ b/src/Rememberme/Storage/File.php
@@ -85,6 +85,19 @@ class File implements StorageInterface
     }
 
     /**
+     * Replace current token after successful authentication
+     * @param $credential
+     * @param $token
+     * @param $persistentToken
+     * @param int $expire
+     */
+    public function replaceTriplet($credential, $token, $persistentToken, $expire = 0)
+    {
+        $this->cleanTriplet($credential, $persistentToken);
+        $this->storeTriplet($credential, $token, $persistentToken, $expire);
+    }
+
+    /**
      * @param $credential
      */
     public function cleanAllTriplets($credential)

--- a/src/Rememberme/Storage/PDO.php
+++ b/src/Rememberme/Storage/PDO.php
@@ -72,6 +72,27 @@ class PDO extends DB
     }
 
     /**
+     * Replace current token after successful authentication
+     * @param $credential
+     * @param $token
+     * @param $persistentToken
+     * @param int $expire
+     */
+    public function replaceTriplet($credential, $token, $persistentToken, $expire = 0)
+    {
+        try {
+            $this->connection->beginTransaction();
+            $this->cleanTriplet($credential, $persistentToken);
+            $this->storeTriplet($credential, $token, $persistentToken, $expire);
+            $this->connection->commit();
+        }
+        catch (\PDOException $e) {
+            $this->connection->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
      * @param $credential
      */
     public function cleanAllTriplets($credential)

--- a/src/Rememberme/Storage/StorageInterface.php
+++ b/src/Rememberme/Storage/StorageInterface.php
@@ -36,6 +36,14 @@ interface StorageInterface
      */
     public function storeTriplet($credential, $token, $persistentToken, $expire = 0);
 
+    /**
+     * Replace current token after successful authentication
+     * @param $credential
+     * @param $token
+     * @param $persistentToken
+     * @param int $expire
+     */
+    public function replaceTriplet($credential, $token, $persistentToken, $expire = 0);
 
     /**
      * Remove one triplet of the user from the store

--- a/test/RemembermeTest.php
+++ b/test/RemembermeTest.php
@@ -88,14 +88,14 @@ class RemembermeTest extends PHPUnit_Framework_TestCase
     $this->rememberme->login();
   }
 
-  public function testStoreNewTripletInStorageIfTripletIsFound() {
+  public function testReplaceTripletInStorageIfTripletIsFound() {
     $_COOKIE[$this->rememberme->getCookieName()] = implode("|", array(
       $this->userid, $this->validToken, $this->validPersistentToken));
     $this->storage->expects($this->once())
       ->method("findTriplet")
       ->will($this->returnValue(Birke\Rememberme\Storage\StorageInterface::TRIPLET_FOUND));
     $this->storage->expects($this->once())
-      ->method("storeTriplet")
+      ->method("replaceTriplet")
       ->with(
         $this->equalTo($this->userid),
         $this->logicalAnd(
@@ -259,7 +259,7 @@ class RemembermeTest extends PHPUnit_Framework_TestCase
       ->with($this->equalTo($this->userid), $this->equalTo($this->validToken.$salt), $this->equalTo($this->validPersistentToken.$salt))
       ->will($this->returnValue(Birke\Rememberme\Storage\StorageInterface::TRIPLET_FOUND));
     $this->storage->expects($this->once())
-      ->method("storeTriplet")
+      ->method("replaceTriplet")
       ->with(
         $this->equalTo($this->userid), 
         $this->matchesRegularExpression('/^[a-f0-9]{32,}'.preg_quote($salt)."$/"), 


### PR DESCRIPTION
Hi,

Using your library I ran into some data inconsistency problems, specifically when two requests try to delete/insert the same data (for instance when using AJAX requests).

At the moment clearTriplet() and storeTriplet() are called sequently and that may cause problem in case of many requests.

To deal with the issue, I think it would be good to create replaceTriplet() method in StorageInterface to have ability to use locks/transaction depending on the storage in use.

Please merge if you're happy with it.

Best,
Bartosz
