### PR TITLE
Use a CSPRNG

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "psr-4": {"Birke\\": "src/"}
     },
     "require": {
-        "php": ">= 5.3.0"
+        "paragonie/random_compat": "^1.1.4"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": ">= 5.3.0"
-    }
+    },
     "require-dev": {
         "phpunit/phpunit": "4.*"
     }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
     "autoload": {
         "psr-4": {"Birke\\": "src/"}
     },
+    "require": {
+        "php": ">= 5.3.0"
+    }
     "require-dev": {
         "phpunit/phpunit": "4.*"
     }

--- a/src/Rememberme/Authenticator.php
+++ b/src/Rememberme/Authenticator.php
@@ -222,7 +222,7 @@ class Authenticator
      */
     protected function createToken()
     {
-        return bin2hex(openssl_random_pseudo_bytes(32))
+        return bin2hex(random_bytes(32))
     }
 
     /**

--- a/src/Rememberme/Authenticator.php
+++ b/src/Rememberme/Authenticator.php
@@ -222,7 +222,7 @@ class Authenticator
      */
     protected function createToken()
     {
-        return md5(uniqid(mt_rand(), true));
+        return bin2hex(openssl_random_pseudo_bytes(32))
     }
 
     /**


### PR DESCRIPTION
`openssl_random_pseudo_bytes()` has been available since PHP 5.3.0. Since the PHP 5.4 branch is now "security patches only", you can expect this to be available.