### PR TITLE
missing semicolon

### DIFF
--- a/src/Rememberme/Authenticator.php
+++ b/src/Rememberme/Authenticator.php
@@ -222,7 +222,7 @@ class Authenticator
      */
     protected function createToken()
     {
-        return bin2hex(random_bytes(32))
+        return bin2hex(random_bytes(32));
     }
 
     /**


### PR DESCRIPTION
fixes
`PHP Parse error:  syntax error, unexpected '}' in [...]\vendor\\birke\\rememberme\\src\\Rememberme\\Authenticator.php on line 226`