### PR TITLE
enable pgsql use

### DIFF
--- a/src/Storage/PDOStorage.php
+++ b/src/Storage/PDOStorage.php
@@ -24,7 +24,7 @@ class PDOStorage extends AbstractDBStorage
     {
         // We don't store the sha1 as binary values because otherwise we could not use
         // proper XML test data
-        $sql = "SELECT IF(SHA1(?) = {$this->tokenColumn}, 1, -1) AS token_match "."FROM {$this->tableName} WHERE {$this->credentialColumn} = ? "."AND {$this->persistentTokenColumn} = SHA1(?) AND {$this->expiresColumn} > NOW() LIMIT 1";
+        $sql = "SELECT CASE WHEN SHA1(?) = {$this->tokenColumn} THEN 1 ELSE -1 END AS token_match "."FROM {$this->tableName} WHERE {$this->credentialColumn} = ? "."AND {$this->persistentTokenColumn} = SHA1(?) AND {$this->expiresColumn} > NOW() LIMIT 1";
 
         $query = $this->connection->prepare($sql);
         $query->execute(array($token, $credential, $persistentToken));


### PR DESCRIPTION
rel #19 
this pr enables you to use the lib with pgsql when you definde the sha1 function, for which you need the pgcrypto packet 

```SQL
CREATE OR REPLACE FUNCTION sha1(bytea) returns text AS $$
      SELECT encode(digest($1, 'sha1'), 'hex')
    $$ LANGUAGE SQL STRICT IMMUTABLE;
```