### PR TITLE
remove MySQL dialect from findTriplet method query

### DIFF
--- a/src/Storage/PDOStorage.php
+++ b/src/Storage/PDOStorage.php
@@ -23,10 +23,10 @@ class PDOStorage extends AbstractDBStorage
     public function findTriplet($credential, $token, $persistentToken)
     {
         $sql = "SELECT $this->tokenColumn as token FROM {$this->tableName} WHERE {$this->credentialColumn} = ? ".
-            "AND {$this->persistentTokenColumn} = ? AND {$this->expiresColumn} > NOW() LIMIT 1";
+            "AND {$this->persistentTokenColumn} = ? AND {$this->expiresColumn} > ? LIMIT 1";
 
         $query = $this->connection->prepare($sql);
-        $query->execute(array($credential, sha1($persistentToken)));
+        $query->execute(array($credential, sha1($persistentToken), date("Y-m-d H:i:s")));
 
         $result = $query->fetchColumn();
 


### PR DESCRIPTION
Hi there,

thanks for your nice job, I've removed the NOW() function call in the findTriplet method query, that was incompatible with the sqlite PDO I'm using for a hobby project.

Please merge at your convenienve, cheers!

 Giorgio