### PR TITLE
Fix cleaning of expired tokens

### DIFF
--- a/src/Authenticator.php
+++ b/src/Authenticator.php
@@ -100,7 +100,7 @@ class Authenticator
         }
 
         if ($this->cleanExpiredTokensOnLogin) {
-            $this->storage->cleanExpiredTokens(time() - $this->expireTime);
+            $this->storage->cleanExpiredTokens(time());
         }
 
         $tripletLookupResult = $this->storage->findTriplet(


### PR DESCRIPTION
The column `$expiresColumn` stores the expiry timestamp, which is calculated like: `$expire = time() + $this->expireTime`.

OTOH, the code to clean the expired tokens looks like this:
```php
if ($this->cleanExpiredTokensOnLogin) {
    $this->storage->cleanExpiredTokens(time() - $this->expireTime);
}
```

This leads to the tokens being valid for **twice** the `expireTime`.